### PR TITLE
adding openAPI 3.0.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,39 @@
 # openapi-schema-validation [![NPM version][npm-image]][npm-url] [![Downloads][downloads-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Coveralls Status][coveralls-image]][coveralls-url]
 > Validate openapi documents.
 
-For OpenAPI v2.0 (a.k.a. swagger 2.0) document examples and documentation, view
-[the official docs](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#itemsObject).
+##For OpenAPI v2.0 (a.k.a. swagger 2.0) and OpenAPI v3.0.0 
+####Document examples and full specs:
+* [Official 2.0 docs](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#itemsObject)
+* [Official 3.0.0 docs](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md)
 
 ## Highlights
 
-* Validate openapi documents against official openapi schema documents.
+* Validate openapi documents against openapi schema documents.
 * Uses [jsonschema](https://github.com/tdegrunt/jsonschema) under the hood.
 * Performant.
 * Currently supports type definitions included in the `definitions` property of the
 provided openapi document.
 * Extensively tested.
 * Small footprint.
-* Currently supports openapi 2.0 (a.k.a. swagger 2.0) documents.
+* Supports openapi 2.0 (a.k.a. swagger 2.0) documents and openapi 3.0.0
+ 
+**Huge thank you to the [gnostic](https://github.com/googleapis/gnostic) project for building up a 3.0.0 JSON schema.**
+ 
 
 ## Example
-
-See `./test/data-driven/*.js` for more examples.
-
 ```javascript
 var validateSchema = require('openapi-schema-validation').validate;
-
-console.log(validateSchema({/* openapi doc */}, {version: 'swagger-2.0'});
+console.log(validateSchema(apiDoc, version));
 ```
+[see here](https://github.com/tdegrunt/jsonschema#results) for example results. 
+
 
 ## API
-### .validate(apiDoc [, args])
-
-`apiDoc` is any api document you wish to validate.
-`[args]` is an optional object the accepts the following arguments:
-* `version` - The openapi document schema version to use.  Currently the only supported
-version is `swagger-2.0` (the default).
+### .validate(apiDoc, version)
+* `apiDoc` _object_ is any api document you wish to validate.
+* `version` _optional number_ openapi document schema version to use (2 or 3). 
+    * 2 - `swagger-2.0` (default)
+    * 3 - `openapi-3.0.0`
 
 ## LICENSE
 ``````

--- a/index.js
+++ b/index.js
@@ -3,15 +3,27 @@ var fs = require('fs');
 var Validator = require('jsonschema').Validator;
 var v = new Validator();
 var jsonSchema = require('jsonschema-draft4');
-var swaggerSchema = require('swagger-schema-official/schema.json');
+var swagger2Schema = require('swagger-schema-official/schema.json');
+var swagger3Schema = require('./schema/openapi-3.0.json');
 
 v.addSchema(jsonSchema);
-v.addSchema(swaggerSchema);
+v.addSchema(swagger2Schema);
+v.addSchema(swagger3Schema);
 
 module.exports = {
   validate: validate
 };
 
-function validate(openapiDoc) {
-  return v.validate(openapiDoc, swaggerSchema);
+/**
+ * Runs specified validator against the provided openapiDocument and returns the results.
+ * Previously the second param was unused. To maintain backward compatibility, if anything other than a
+ * Number is passed, the v2 validator will be used.
+ *
+ * @param openapiDoc {object} to be validated
+ * @param version {Number} defaults to 2 if unspecified or invalid type is passed
+ * @returns {object} results from the validator
+ */
+function validate(openapiDoc, version) {
+  version = typeof version === "number" ? version : 2; // default to swagger 2.0 validation
+  return v.validate(openapiDoc, version === 2 || version === 2.0 ? swagger2Schema : swagger3Schema);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-schema-validation",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Validate openapi documents.",
   "scripts": {
     "cover": "istanbul cover _mocha -- ./test/*.js",

--- a/schema/openapi-3.0.json
+++ b/schema/openapi-3.0.json
@@ -1,0 +1,1248 @@
+{
+  "title": "A JSON Schema for OpenAPI 3.0.",
+  "id": "http://openapis.org/v3/schema.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "This is the root document object of the OpenAPI document.",
+  "required": [
+    "openapi",
+    "info",
+    "paths"
+  ],
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-": {
+      "$ref": "#/definitions/specificationExtension"
+    }
+  },
+  "properties": {
+    "openapi": {
+      "type": "string"
+    },
+    "info": {
+      "$ref": "#/definitions/info"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/server"
+      },
+      "uniqueItems": true
+    },
+    "paths": {
+      "$ref": "#/definitions/paths"
+    },
+    "components": {
+      "$ref": "#/definitions/components"
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/securityRequirement"
+      },
+      "uniqueItems": true
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/tag"
+      },
+      "uniqueItems": true
+    },
+    "externalDocs": {
+      "$ref": "#/definitions/externalDocs"
+    }
+  },
+  "definitions": {
+    "info": {
+      "type": "object",
+      "description": "The object provides metadata about the API. The metadata MAY be used by the clients if needed, and MAY be presented in editing or documentation generation tools for convenience.",
+      "required": [
+        "title",
+        "version"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "termsOfService": {
+          "type": "string"
+        },
+        "contact": {
+          "$ref": "#/definitions/contact"
+        },
+        "license": {
+          "$ref": "#/definitions/license"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "contact": {
+      "type": "object",
+      "description": "Contact information for the exposed API.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        }
+      }
+    },
+    "license": {
+      "type": "object",
+      "description": "License information for the exposed API.",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "server": {
+      "type": "object",
+      "description": "An object representing a Server.",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "variables": {
+          "$ref": "#/definitions/serverVariables"
+        }
+      }
+    },
+    "serverVariable": {
+      "type": "object",
+      "description": "An object representing a Server Variable for server URL template substitution.",
+      "required": [
+        "default"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "components": {
+      "type": "object",
+      "description": "Holds a set of reusable objects for different aspects of the OAS. All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "schemas": {
+          "$ref": "#/definitions/schemasOrReferences"
+        },
+        "responses": {
+          "$ref": "#/definitions/responsesOrReferences"
+        },
+        "parameters": {
+          "$ref": "#/definitions/parametersOrReferences"
+        },
+        "examples": {
+          "$ref": "#/definitions/examplesOrReferences"
+        },
+        "requestBodies": {
+          "$ref": "#/definitions/requestBodiesOrReferences"
+        },
+        "headers": {
+          "$ref": "#/definitions/headersOrReferences"
+        },
+        "securitySchemes": {
+          "$ref": "#/definitions/securitySchemesOrReferences"
+        },
+        "links": {
+          "$ref": "#/definitions/linksOrReferences"
+        },
+        "callbacks": {
+          "$ref": "#/definitions/callbacksOrReferences"
+        }
+      }
+    },
+    "paths": {
+      "type": "object",
+      "description": "Holds the relative paths to the individual endpoints and their operations. The path is appended to the URL from the `Server Object` in order to construct the full URL.  The Paths MAY be empty, due to ACL constraints.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^/": {
+          "$ref": "#/definitions/pathItem"
+        },
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      }
+    },
+    "pathItem": {
+      "type": "object",
+      "description": "Describes the operations available on a single path. A Path Item MAY be empty, due to ACL constraints. The path itself is still exposed to the documentation viewer but they will not know which operations and parameters are available.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "get": {
+          "$ref": "#/definitions/operation"
+        },
+        "put": {
+          "$ref": "#/definitions/operation"
+        },
+        "post": {
+          "$ref": "#/definitions/operation"
+        },
+        "delete": {
+          "$ref": "#/definitions/operation"
+        },
+        "options": {
+          "$ref": "#/definitions/operation"
+        },
+        "head": {
+          "$ref": "#/definitions/operation"
+        },
+        "patch": {
+          "$ref": "#/definitions/operation"
+        },
+        "trace": {
+          "$ref": "#/definitions/operation"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/server"
+          },
+          "uniqueItems": true
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/parameterOrReference"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "operation": {
+      "type": "object",
+      "description": "Describes a single API operation on a path.",
+      "required": [
+        "responses"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/parameterOrReference"
+          },
+          "uniqueItems": true
+        },
+        "requestBody": {
+          "$ref": "#/definitions/requestBodyOrReference"
+        },
+        "responses": {
+          "$ref": "#/definitions/responses"
+        },
+        "callbacks": {
+          "$ref": "#/definitions/callbacksOrReferences"
+        },
+        "deprecated": {
+          "type": "boolean"
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/securityRequirement"
+          },
+          "uniqueItems": true
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/server"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "externalDocs": {
+      "type": "object",
+      "description": "Allows referencing an external resource for extended documentation.",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "parameter": {
+      "type": "object",
+      "description": "Describes a single operation parameter.  A unique parameter is defined by a combination of a name and location.",
+      "required": [
+        "name",
+        "in"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "deprecated": {
+          "type": "boolean"
+        },
+        "allowEmptyValue": {
+          "type": "boolean"
+        },
+        "style": {
+          "type": "string"
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean"
+        },
+        "schema": {
+          "$ref": "#/definitions/schemaOrReference"
+        },
+        "example": {
+          "$ref": "#/definitions/any"
+        },
+        "examples": {
+          "$ref": "#/definitions/examplesOrReferences"
+        },
+        "content": {
+          "$ref": "#/definitions/mediaTypes"
+        }
+      }
+    },
+    "requestBody": {
+      "type": "object",
+      "description": "Describes a single request body.",
+      "required": [
+        "content"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/definitions/mediaTypes"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "mediaType": {
+      "type": "object",
+      "description": "Each Media Type Object provides schema and examples for the media type identified by its key.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "schema": {
+          "$ref": "#/definitions/schemaOrReference"
+        },
+        "example": {
+          "$ref": "#/definitions/any"
+        },
+        "examples": {
+          "$ref": "#/definitions/examplesOrReferences"
+        },
+        "encoding": {
+          "$ref": "#/definitions/encodings"
+        }
+      }
+    },
+    "encoding": {
+      "type": "object",
+      "description": "A single encoding definition applied to a single schema property.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "contentType": {
+          "type": "string"
+        },
+        "headers": {
+          "$ref": "#/definitions/headersOrReferences"
+        },
+        "style": {
+          "type": "string"
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean"
+        }
+      }
+    },
+    "responses": {
+      "type": "object",
+      "description": "A container for the expected responses of an operation. The container maps a HTTP response code to the expected response.  The documentation is not necessarily expected to cover all possible HTTP response codes because they may not be known in advance. However, documentation is expected to cover a successful operation response and any known errors.  The `default` MAY be used as a default response object for all HTTP codes  that are not covered individually by the specification.  The `Responses Object` MUST contain at least one response code, and it  SHOULD be the response for a successful operation call.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^([0-9X]{3})$": {
+          "$ref": "#/definitions/responseOrReference"
+        },
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "default": {
+          "$ref": "#/definitions/responseOrReference"
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "description": "Describes a single response from an API Operation, including design-time, static  `links` to operations based on the response.",
+      "required": [
+        "description"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "$ref": "#/definitions/headersOrReferences"
+        },
+        "content": {
+          "$ref": "#/definitions/mediaTypes"
+        },
+        "links": {
+          "$ref": "#/definitions/linksOrReferences"
+        }
+      }
+    },
+    "callback": {
+      "type": "object",
+      "description": "A map of possible out-of band callbacks related to the parent operation. Each value in the map is a Path Item Object that describes a set of requests that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^": {
+          "$ref": "#/definitions/pathItem"
+        },
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      }
+    },
+    "example": {
+      "type": "object",
+      "description": "",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/definitions/any"
+        },
+        "externalValue": {
+          "type": "string"
+        }
+      }
+    },
+    "link": {
+      "type": "object",
+      "description": "The `Link object` represents a possible design-time link for a response. The presence of a link does not guarantee the caller's ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.  Unlike _dynamic_ links (i.e. links provided **in** the response payload), the OAS linking mechanism does not require link information in the runtime response.  For computing links, and providing instructions to execute them, a runtime expression is used for accessing values in an operation and using them as parameters while invoking the linked operation.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "operationRef": {
+          "type": "string"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/definitions/anysOrExpressions"
+        },
+        "requestBody": {
+          "$ref": "#/definitions/anyOrExpression"
+        },
+        "description": {
+          "type": "string"
+        },
+        "server": {
+          "$ref": "#/definitions/server"
+        }
+      }
+    },
+    "header": {
+      "type": "object",
+      "description": "The Header Object follows the structure of the Parameter Object with the following changes:  1. `name` MUST NOT be specified, it is given in the corresponding `headers` map. 1. `in` MUST NOT be specified, it is implicitly in `header`. 1. All traits that are affected by the location MUST be applicable to a location of `header` (for example, `style`).",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "deprecated": {
+          "type": "boolean"
+        },
+        "allowEmptyValue": {
+          "type": "boolean"
+        },
+        "style": {
+          "type": "string"
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean"
+        },
+        "schema": {
+          "$ref": "#/definitions/schemaOrReference"
+        },
+        "example": {
+          "$ref": "#/definitions/any"
+        },
+        "examples": {
+          "$ref": "#/definitions/examplesOrReferences"
+        },
+        "content": {
+          "$ref": "#/definitions/mediaTypes"
+        }
+      }
+    },
+    "tag": {
+      "type": "object",
+      "description": "Adds metadata to a single tag that is used by the Operation Object. It is not mandatory to have a Tag Object per tag defined in the Operation Object instances.",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        }
+      }
+    },
+    "examples": {
+      "type": "object",
+      "description": "",
+      "additionalProperties": false
+    },
+    "reference": {
+      "type": "object",
+      "description": "A simple object to allow referencing other components in the specification, internally and externally.  The Reference Object is defined by JSON Reference and follows the same structure, behavior and rules.   For this specification, reference resolution is accomplished as defined by the JSON Reference specification and not by the JSON Schema specification.",
+      "required": [
+        "$ref"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "$ref": {
+          "type": "string"
+        }
+      }
+    },
+    "schema": {
+      "type": "object",
+      "description": "The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is an extended subset of the JSON Schema Specification Wright Draft 00.  For more information about the properties, see JSON Schema Core and JSON Schema Validation. Unless stated otherwise, the property definitions follow the JSON Schema.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "nullable": {
+          "type": "boolean"
+        },
+        "discriminator": {
+          "$ref": "#/definitions/discriminator"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "writeOnly": {
+          "type": "boolean"
+        },
+        "xml": {
+          "$ref": "#/definitions/xml"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "example": {
+          "$ref": "#/definitions/any"
+        },
+        "deprecated": {
+          "type": "boolean"
+        },
+        "title": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+        },
+        "multipleOf": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+        },
+        "maximum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maxLength"
+        },
+        "minLength": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minLength"
+        },
+        "pattern": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+        },
+        "maxItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maxItems"
+        },
+        "minItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+        },
+        "maxProperties": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maxProperties"
+        },
+        "minProperties": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minProperties"
+        },
+        "required": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/required"
+        },
+        "enum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+        },
+        "type": {
+          "type": "string"
+        },
+        "allOf": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/schemaOrReference"
+          },
+          "minItems": 1
+        },
+        "oneOf": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/schemaOrReference"
+          },
+          "minItems": 1
+        },
+        "anyOf": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/schemaOrReference"
+          },
+          "minItems": 1
+        },
+        "not": {
+          "$ref": "#/definitions/schema"
+        },
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/schemaOrReference"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/schemaOrReference"
+              },
+              "minItems": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/schemaOrReference"
+          }
+        },
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/schemaOrReference"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        },
+        "default": {
+          "$ref": "#/definitions/defaultType"
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        }
+      }
+    },
+    "discriminator": {
+      "type": "object",
+      "description": "When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the specification of an alternative schema based on the value associated with it.  When using the discriminator, _inline_ schemas will not be considered.",
+      "required": [
+        "propertyName"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "propertyName": {
+          "type": "string"
+        },
+        "mapping": {
+          "$ref": "#/definitions/strings"
+        }
+      }
+    },
+    "xml": {
+      "type": "object",
+      "description": "A metadata object that allows for more fine-tuned XML model definitions.  When using arrays, XML element names are *not* inferred (for singular/plural forms) and the `name` property SHOULD be used to add that information. See examples for expected behavior.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "attribute": {
+          "type": "boolean"
+        },
+        "wrapped": {
+          "type": "boolean"
+        }
+      }
+    },
+    "securityScheme": {
+      "type": "object",
+      "description": "Defines a security scheme that can be used by the operations. Supported schemes are HTTP authentication, an API key (either as a header or as a query parameter), OAuth2's common flows (implicit, password, application and access code) as defined in RFC6749, and OpenID Connect Discovery.",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "bearerFormat": {
+          "type": "string"
+        },
+        "flows": {
+          "$ref": "#/definitions/oauthFlows"
+        },
+        "openIdConnectUrl": {
+          "type": "string"
+        }
+      }
+    },
+    "oauthFlows": {
+      "type": "object",
+      "description": "Allows configuration of the supported OAuth Flows.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "implicit": {
+          "$ref": "#/definitions/oauthFlow"
+        },
+        "password": {
+          "$ref": "#/definitions/oauthFlow"
+        },
+        "clientCredentials": {
+          "$ref": "#/definitions/oauthFlow"
+        },
+        "authorizationCode": {
+          "$ref": "#/definitions/oauthFlow"
+        }
+      }
+    },
+    "oauthFlow": {
+      "type": "object",
+      "description": "Configuration details for a supported OAuth Flow",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
+      "properties": {
+        "authorizationUrl": {
+          "type": "string"
+        },
+        "tokenUrl": {
+          "type": "string"
+        },
+        "refreshUrl": {
+          "type": "string"
+        },
+        "scopes": {
+          "$ref": "#/definitions/strings"
+        }
+      }
+    },
+    "securityRequirement": {
+      "type": "object",
+      "description": "Lists the required security schemes to execute this operation. The name used for each property MUST correspond to a security scheme declared in the Security Schemes under the Components Object.  Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized. This enables support for scenarios where multiple query parameters or HTTP headers are required to convey security information.  When a list of Security Requirement Objects is defined on the Open API object or Operation Object, only one of Security Requirement Objects in the list needs to be satisfied to authorize the request.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9\\.\\-_]+$": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "anyOrExpression": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/any"
+        },
+        {
+          "$ref": "#/definitions/expression"
+        }
+      ]
+    },
+    "callbackOrReference": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/callback"
+        },
+        {
+          "$ref": "#/definitions/reference"
+        }
+      ]
+    },
+    "exampleOrReference": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/example"
+        },
+        {
+          "$ref": "#/definitions/reference"
+        }
+      ]
+    },
+    "headerOrReference": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/header"
+        },
+        {
+          "$ref": "#/definitions/reference"
+        }
+      ]
+    },
+    "linkOrReference": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/link"
+        },
+        {
+          "$ref": "#/definitions/reference"
+        }
+      ]
+    },
+    "parameterOrReference": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/parameter"
+        },
+        {
+          "$ref": "#/definitions/reference"
+        }
+      ]
+    },
+    "requestBodyOrReference": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/requestBody"
+        },
+        {
+          "$ref": "#/definitions/reference"
+        }
+      ]
+    },
+    "responseOrReference": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/response"
+        },
+        {
+          "$ref": "#/definitions/reference"
+        }
+      ]
+    },
+    "schemaOrReference": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/schema"
+        },
+        {
+          "$ref": "#/definitions/reference"
+        }
+      ]
+    },
+    "securitySchemeOrReference": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/securityScheme"
+        },
+        {
+          "$ref": "#/definitions/reference"
+        }
+      ]
+    },
+    "anysOrExpressions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/anyOrExpression"
+      }
+    },
+    "callbacksOrReferences": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/callbackOrReference"
+      }
+    },
+    "encodings": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/encoding"
+      }
+    },
+    "examplesOrReferences": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/exampleOrReference"
+      }
+    },
+    "headersOrReferences": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/headerOrReference"
+      }
+    },
+    "linksOrReferences": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/linkOrReference"
+      }
+    },
+    "mediaTypes": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/mediaType"
+      }
+    },
+    "parametersOrReferences": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/parameterOrReference"
+      }
+    },
+    "requestBodiesOrReferences": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/requestBodyOrReference"
+      }
+    },
+    "responsesOrReferences": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/responseOrReference"
+      }
+    },
+    "schemasOrReferences": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/schemaOrReference"
+      }
+    },
+    "securitySchemesOrReferences": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/securitySchemeOrReference"
+      }
+    },
+    "serverVariables": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/serverVariable"
+      }
+    },
+    "strings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "object": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "any": {
+      "additionalProperties": true
+    },
+    "expression": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "specificationExtension": {
+      "description": "Any property starting with x- is valid.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        },
+        {
+          "type": "array"
+        }
+      ]
+    },
+    "defaultType": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "array"
+        },
+        {
+          "type": "object"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  }
+}

--- a/test/data-driven.js
+++ b/test/data-driven.js
@@ -9,9 +9,8 @@ describe(require('../package.json').name, function() {
     glob.sync('*.js', {cwd: baseDir}).forEach(function(fixture) {
       var testName = path.basename(fixture, '.js').replace(/-/g, ' ');
       fixture = require(path.resolve(baseDir, fixture));
-
       it('should ' + testName, function() {
-        var errors = sut.validate(fixture.apiDoc).errors;
+        var errors = sut.validate(fixture.apiDoc, fixture.validator).errors;
         expect(JSON.stringify(errors, null, '  '))
             .to.equal(JSON.stringify(fixture.errors, null, '  '));
       });

--- a/test/data-driven/accept-valid-v2-documents.js
+++ b/test/data-driven/accept-valid-v2-documents.js
@@ -1,4 +1,5 @@
 module.exports = {
+  validator: 2,
   apiDoc: {
     swagger: '2.0',
     info: {

--- a/test/data-driven/accept-valid-v3-documents.js
+++ b/test/data-driven/accept-valid-v3-documents.js
@@ -1,0 +1,180 @@
+module.exports = {
+  validator: 3,
+  apiDoc: {
+    "openapi": "3.0.0",
+    "info": {
+      "version": "1.0.0",
+      "title": "Swagger Petstore",
+      "license": {
+        "name": "MIT"
+      }
+    },
+    "servers": [
+      {
+        "url": "http://petstore.swagger.io/v1"
+      }
+    ],
+    "paths": {
+      "/pets": {
+        "get": {
+          "summary": "List all pets",
+          "operationId": "listPets",
+          "tags": [
+            "pets"
+          ],
+          "parameters": [
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "How many items to return at one time (max 100)",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "An paged array of pets",
+              "headers": {
+                "x-next": {
+                  "description": "A link to the next page of responses",
+                  "schema": {
+                    "type": "string"
+                  }
+                }
+              },
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Pets"
+                  }
+                }
+              }
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "summary": "Create a pet",
+          "operationId": "createPets",
+          "tags": [
+            "pets"
+          ],
+          "responses": {
+            "201": {
+              "description": "Null response"
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/pets/{petId}": {
+        "get": {
+          "summary": "Info for a specific pet",
+          "operationId": "showPetById",
+          "tags": [
+            "pets"
+          ],
+          "parameters": [
+            {
+              "name": "petId",
+              "in": "path",
+              "required": true,
+              "description": "The id of the pet to retrieve",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Expected response to a valid request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Pets"
+                  }
+                }
+              }
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "Pet": {
+          "required": [
+            "id",
+            "name"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "name": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
+        },
+        "Pets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/Pet"
+          }
+        },
+        "Error": {
+          "required": [
+            "code",
+            "message"
+          ],
+          "properties": {
+            "code": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "message": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+
+  },
+  errors: []
+};

--- a/test/data-driven/fail-invalid-v2-documents.js
+++ b/test/data-driven/fail-invalid-v2-documents.js
@@ -1,4 +1,5 @@
 module.exports = {
+  validator: 2,
   apiDoc: {
     info: {
       title: 'Some valid API document',

--- a/test/data-driven/fail-invalid-v3-documents.js
+++ b/test/data-driven/fail-invalid-v3-documents.js
@@ -1,0 +1,374 @@
+module.exports = {
+  validator: 3,
+  apiDoc: {
+    "swagger": "3.0.0",
+    "info": {
+      "version": "1.0.0",
+      "title": "Swagger Petstore",
+      "license": {
+        "name": "MIT"
+      }
+    },
+    "servers": [
+      {
+        "url": "http://petstore.swagger.io/v1"
+      }
+    ],
+    "paths": {
+      "/pets": {
+        "get": {
+          "summary": "List all pets",
+          "operationId": "listPets",
+          "tags": [
+            "pets"
+          ],
+          "parameters": [
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "How many items to return at one time (max 100)",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "An paged array of pets",
+              "headers": {
+                "x-next": {
+                  "description": "A link to the next page of responses",
+                  "schema": {
+                    "type": "string"
+                  }
+                }
+              },
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Pets"
+                  }
+                }
+              }
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "summary": "Create a pet",
+          "operationId": "createPets",
+          "tags": [
+            "pets"
+          ],
+          "responses": {
+            "201": {
+              "description": "Null response"
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/pets/{petId}": {
+        "get": {
+          "summary": "Info for a specific pet",
+          "operationId": "showPetById",
+          "tags": [
+            "pets"
+          ],
+          "parameters": [
+            {
+              "name": "petId",
+              "in": "path",
+              "required": true,
+              "description": "The id of the pet to retrieve",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Expected response to a valid request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Pets"
+                  }
+                }
+              }
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "Pet": {
+          "required": [
+            "id",
+            "name"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "name": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
+        },
+        "Pets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/Pet"
+          }
+        },
+        "Error": {
+          "required": [
+            "code",
+            "message"
+          ],
+          "properties": {
+            "code": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "message": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+
+  },
+  errors: [{
+    "property": "instance",
+    "message": "requires property \"openapi\"",
+    "schema": "http://openapis.org/v3/schema.json#",
+    "instance": {
+      "swagger": "3.0.0",
+      "info": {"version": "1.0.0", "title": "Swagger Petstore", "license": {"name": "MIT"}},
+      "servers": [{"url": "http://petstore.swagger.io/v1"}],
+      "paths": {
+        "/pets": {
+          "get": {
+            "summary": "List all pets",
+            "operationId": "listPets",
+            "tags": ["pets"],
+            "parameters": [{
+              "name": "limit",
+              "in": "query",
+              "description": "How many items to return at one time (max 100)",
+              "required": false,
+              "schema": {"type": "integer", "format": "int32"}
+            }],
+            "responses": {
+              "200": {
+                "description": "An paged array of pets",
+                "headers": {
+                  "x-next": {
+                    "description": "A link to the next page of responses",
+                    "schema": {"type": "string"}
+                  }
+                },
+                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Pets"}}}
+              },
+              "default": {
+                "description": "unexpected error",
+                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+              }
+            }
+          },
+          "post": {
+            "summary": "Create a pet",
+            "operationId": "createPets",
+            "tags": ["pets"],
+            "responses": {
+              "201": {"description": "Null response"},
+              "default": {
+                "description": "unexpected error",
+                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+              }
+            }
+          }
+        },
+        "/pets/{petId}": {
+          "get": {
+            "summary": "Info for a specific pet",
+            "operationId": "showPetById",
+            "tags": ["pets"],
+            "parameters": [{
+              "name": "petId",
+              "in": "path",
+              "required": true,
+              "description": "The id of the pet to retrieve",
+              "schema": {"type": "string"}
+            }],
+            "responses": {
+              "200": {
+                "description": "Expected response to a valid request",
+                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Pets"}}}
+              },
+              "default": {
+                "description": "unexpected error",
+                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+              }
+            }
+          }
+        }
+      },
+      "components": {
+        "schemas": {
+          "Pet": {
+            "required": ["id", "name"],
+            "properties": {
+              "id": {"type": "integer", "format": "int64"},
+              "name": {"type": "string"},
+              "tag": {"type": "string"}
+            }
+          },
+          "Pets": {"type": "array", "items": {"$ref": "#/components/schemas/Pet"}},
+          "Error": {
+            "required": ["code", "message"],
+            "properties": {"code": {"type": "integer", "format": "int32"}, "message": {"type": "string"}}
+          }
+        }
+      }
+    },
+    "name": "required",
+    "argument": "openapi",
+    "stack": "instance requires property \"openapi\""
+  }, {
+    "property": "instance",
+    "message": "additionalProperty \"swagger\" exists in instance when not allowed",
+    "schema": "http://openapis.org/v3/schema.json#",
+    "instance": {
+      "swagger": "3.0.0",
+      "info": {"version": "1.0.0", "title": "Swagger Petstore", "license": {"name": "MIT"}},
+      "servers": [{"url": "http://petstore.swagger.io/v1"}],
+      "paths": {
+        "/pets": {
+          "get": {
+            "summary": "List all pets",
+            "operationId": "listPets",
+            "tags": ["pets"],
+            "parameters": [{
+              "name": "limit",
+              "in": "query",
+              "description": "How many items to return at one time (max 100)",
+              "required": false,
+              "schema": {"type": "integer", "format": "int32"}
+            }],
+            "responses": {
+              "200": {
+                "description": "An paged array of pets",
+                "headers": {
+                  "x-next": {
+                    "description": "A link to the next page of responses",
+                    "schema": {"type": "string"}
+                  }
+                },
+                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Pets"}}}
+              },
+              "default": {
+                "description": "unexpected error",
+                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+              }
+            }
+          },
+          "post": {
+            "summary": "Create a pet",
+            "operationId": "createPets",
+            "tags": ["pets"],
+            "responses": {
+              "201": {"description": "Null response"},
+              "default": {
+                "description": "unexpected error",
+                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+              }
+            }
+          }
+        },
+        "/pets/{petId}": {
+          "get": {
+            "summary": "Info for a specific pet",
+            "operationId": "showPetById",
+            "tags": ["pets"],
+            "parameters": [{
+              "name": "petId",
+              "in": "path",
+              "required": true,
+              "description": "The id of the pet to retrieve",
+              "schema": {"type": "string"}
+            }],
+            "responses": {
+              "200": {
+                "description": "Expected response to a valid request",
+                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Pets"}}}
+              },
+              "default": {
+                "description": "unexpected error",
+                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+              }
+            }
+          }
+        }
+      },
+      "components": {
+        "schemas": {
+          "Pet": {
+            "required": ["id", "name"],
+            "properties": {
+              "id": {"type": "integer", "format": "int64"},
+              "name": {"type": "string"},
+              "tag": {"type": "string"}
+            }
+          },
+          "Pets": {"type": "array", "items": {"$ref": "#/components/schemas/Pet"}},
+          "Error": {
+            "required": ["code", "message"],
+            "properties": {"code": {"type": "integer", "format": "int32"}, "message": {"type": "string"}}
+          }
+        }
+      }
+    },
+    "name": "additionalProperties",
+    "argument": "swagger",
+    "stack": "instance additionalProperty \"swagger\" exists in instance when not allowed"
+  }]
+};


### PR DESCRIPTION
Added openAPI 3.0.0 JSON schema and made some adjustments to determine which schema the validator should use.

It looks [like a pr was opened](https://github.com/OAI/OpenAPI-Specification/pull/1236) for adding the v3 schema to the OpenAPI spec repo, but it hasn't been merged yet. If/when this gets merged the [require statement](https://github.com/kogosoftwarellc/openapi-schema-validation/compare/master...blortfish:swagger-3?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR7) should be updated to use the new module / file.